### PR TITLE
Advance export options / command arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "mysql-migrator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "mysql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysql-migrator"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ MySQL Migrator is a Rust-based utility designed to migrate tables from one MySQL
     - **tables**: An array of tables in the destination database to be migrated. Each table is represented by an object that contains:
         - **name**: The name of the table in the destination database. This should match the rename field of the corresponding table in the source database. If the rename field was not specified in the source database, this should match the original table name.
 
+## Arguments
+- `--config`: Specify the configuration file of the migration. Default is "config.json".
+- `--extended-insert`: Use extended `INSERT` statements.
+- `--complete-insert`: Include column names in `INSERT` statements.
+- `--insert-ignore`: Use `INSERT IGNORE` instead of `INSERT`.
+- `--export-only`: Run in export-only mode. Skip the import process.
+- `--extended-insert-limit`: Limit the number of rows in extended `INSERT` statements. Default is 50.
+- `--clean`: Clean previous exports before running the program.
+- `h`, `--help`: Print help.
+- `V`, `--version`: Print version.
 
 ## Todo
 - export multi-threaded

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -7,4 +7,28 @@ pub struct Args {
     /// The configuration file of the migration
     #[arg(long)]
     pub config: Option<String>,
+
+    /// Use extended insert statements
+    #[arg(long)]
+    pub extended_insert: bool,
+
+    /// Include column names in insert statements
+    #[arg(long)]
+    pub complete_insert: bool,
+
+    /// Use INSERT IGNORE instead of INSERT
+    #[arg(long)]
+    pub insert_ignore: bool,
+
+    /// Run in export only mode
+    #[arg(long)]
+    pub export_only: bool,
+
+    /// Limit the number of rows in extended insert statements
+    #[arg(long, default_value_t = 50)]
+    pub extended_insert_limit: usize,
+
+    /// Clean previous exports
+    #[arg(long)]
+    pub clean: bool
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,6 +1,5 @@
 use mysql::*;
 use mysql::prelude::*;
-
 use crate::DatabaseConfig;
 
 pub struct Database {

--- a/src/table_importer.rs
+++ b/src/table_importer.rs
@@ -1,8 +1,15 @@
+use crate::TableConfig;
 use crate::database::Database;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
+use std::io::BufRead;
 use mysql::prelude::Queryable;
-pub fn import_table(db: &mut Database, file_name: &str) {
+
+pub fn import_table(
+    db: &mut Database,
+    table: &TableConfig,
+    file_name: &str
+) {
     let path: String = format!("data/{}", file_name);
     let file: File = File::open(path).expect("Unable to open file");
     let reader: BufReader<File> = BufReader::new(file);
@@ -10,4 +17,5 @@ pub fn import_table(db: &mut Database, file_name: &str) {
         let query: String = line.expect("Unable to read line");
         db.conn.query_drop(query).expect("Query execution failed");
     }
+    println!("import {}: completed", &table.name);
 }


### PR DESCRIPTION
## Description
This pull request implements the following command-line arguments:

--extended-insert: Enables the use of extended INSERT statements in the exported SQL file.
--complete-insert: Includes column names in INSERT statements in the exported SQL file.
--insert-ignore: Uses INSERT IGNORE instead of INSERT in the exported SQL file.
--export-only: Runs the program in export-only mode, skipping the import process.
--extended-insert-limit: Limits the number of rows in extended INSERT statements. The default value is 50.
--clean: Cleans previous exports before running the program.
These arguments provide more flexibility and control over the database migration process. Users can now customize the format of the exported SQL file, choose to skip the import process, limit the size of INSERT statements, and clean previous exports.

## Changes
Added new fields to the Args struct in arguments.rs to handle the new arguments.
Updated the Args::parse function to parse the new arguments.
Updated the export_table function in table_exporter.rs to use the new arguments when exporting a table.
Updated the main function in main.rs to pass the new arguments to the export_table function.